### PR TITLE
Aliases for commands

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -231,9 +231,9 @@ class App {
 				let abort = false;
 				for (let alias in command.aliases) {
 					let aliasName = command.aliases[alias];
-					let validAliasName = command.caseSensitive ? aliasName : aliasName.toLowerCase();
+					let validAName = command.caseSensitive ? aliasName : aliasName.toLowerCase();
 						
-					if (validUserInput === validAliasName) {
+					if (validUserInput === validAName) {
 						cmd = command;
 						abort = true;
 						break;

--- a/lib/App.js
+++ b/lib/App.js
@@ -226,21 +226,22 @@ class App {
 			if (validCommandName === validUserInput) {
 				cmd = command;
 				break;
-			}
-			
-			// check if a command alias was provided instead
-			else {
-				let abort = false;				
+			} else {
+				// Check whether the command's alias has been entered instead
+				let abort = false;
 				for (let alias in command.aliases) {
-					let validAliasName = command.caseSensitive ? command.aliases[alias] : command.aliases[alias].toLowerCase();
+					let aliasName = command.aliases[alias];
+					let validAliasName = command.caseSensitive ? aliasName : aliasName.toLowerCase();
 						
-					if(validUserInput === validAliasName) {
+					if (validUserInput === validAliasName) {
 						cmd = command;
 						abort = true;
 						break;
 					}
 						
-					if(abort) break;
+					if (abort) {
+						break;
+					}
 				}
 			}
 		}

--- a/lib/App.js
+++ b/lib/App.js
@@ -227,6 +227,22 @@ class App {
 				cmd = command;
 				break;
 			}
+			
+			// check if a command alias was provided instead
+			else {
+				let abort = false;				
+				for (let alias in command.aliases) {
+					let validAliasName = command.caseSensitive ? command.aliases[alias] : command.aliases[alias].toLowerCase();
+						
+					if(validUserInput === validAliasName) {
+						cmd = command;
+						abort = true;
+						break;
+					}
+						
+					if(abort) break;
+				}
+			}
 		}
 
 		if (!cmd) {

--- a/lib/Command.js
+++ b/lib/Command.js
@@ -100,8 +100,11 @@ class Command {
 			(
 				options.async &&
 				typeof options.async !== "boolean"
-			)                                                  // async is not required
-
+			)                                               || // async is not required
+			(
+				options.aliases &&
+				!Array.isArray(options.aliases)                // aliases is not required
+			)
 
 		) {
 			throw new Error("Wrong parameters passed when creating command " + options.name +
@@ -146,6 +149,17 @@ class Command {
 			}
 
 		}
+		
+		this.aliases = {};
+		options.aliases = options.aliases || [];
+		for (var i = 0; i < options.aliases.length; i++) {
+
+			if (typeof options.aliases[i] === "string") {
+				this.aliases[i] = options.aliases[i];
+			} else {
+				throw new Error("One of the items in the aliases array is not a string.");
+			}
+		}
 	}
 
 	/**
@@ -158,7 +172,18 @@ class Command {
 	_getHelp(app) {
 		const LINE_WIDTH = 100;
 
-		let r = str.help_usage + " " + app.prefix + " " + this.name;
+		let r = str.help_usage + " " + app.prefix + " " + this.name + "\n";
+		
+		// Add aliases
+		if(this.aliases.length > 0) {
+			r += "Aliases for this command: ";
+				for(let i in this.aliases) {
+					r += this.aliases[i];
+					if((i + 1) < this.aliases.length) r += ",";
+				}
+			r += "\n";
+		}
+			
 		let args_table;
 
 		// Add every argument to the usage (Only if there are arguments)

--- a/lib/Command.js
+++ b/lib/Command.js
@@ -152,7 +152,7 @@ class Command {
 		
 		this.aliases = {};
 		options.aliases = options.aliases || [];
-		for (var i = 0; i < options.aliases.length; i++) {
+		for (let i = 0; i < options.aliases.length; i++) {
 
 			if (typeof options.aliases[i] === "string") {
 				this.aliases[i] = options.aliases[i];
@@ -175,12 +175,14 @@ class Command {
 		let r = str.help_usage + " " + app.prefix + " " + this.name + "\n";
 		
 		// Add aliases
-		if(this.aliases.length > 0) {
+		if (this.aliases.length > 0) {
 			r += "Aliases for this command: ";
-				for(let i in this.aliases) {
-					r += this.aliases[i];
-					if((i + 1) < this.aliases.length) r += ",";
+			for (let i in this.aliases) {
+				r += this.aliases[i];
+				if ((i + 1) < this.aliases.length) {
+					r += ",";
 				}
+			}
 			r += "\n";
 		}
 			


### PR DESCRIPTION
This implements the ability to define aliases for any command. Command objects now take an additional member "aliases", an array of strings, which can be used in place of the command's full name and will function just the same.

Cleanup and resubmission of #14.